### PR TITLE
Specify known range of working versions of tera

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["toml", "json"]
 [dependencies]
 clap = "~2"
 anyhow = "~1"
-tera = "^1.5.0"
+tera = "<1.14.0"
 mdbook = "0.4"
 serde = "~1"
 globwalk = "0.8"


### PR DESCRIPTION
Fixes #7 by specifying a known range of working versions of tera (<1.14).

I did not add the `Cargo.lock` to git because I saw it in the `.gitignore` and did not want to override your decision.